### PR TITLE
Use monospace font for variable spans to prevent layout shift

### DIFF
--- a/src/template/render.rs
+++ b/src/template/render.rs
@@ -24,7 +24,7 @@ impl Template {
                 Segment::Literal(text) => span(&**text),
                 Segment::Variable(var) => {
                     let (text, color) = self.resolve_variable(*var, data, colors);
-                    span(text).color_maybe(color)
+                    span(text).font(cosmic::font::mono()).color_maybe(color)
                 }
                 Segment::Unknown(name) => span(format!("{{{name}}}")).color(colors.red),
             })


### PR DESCRIPTION
<img width="1066" height="125" alt="image" src="https://github.com/user-attachments/assets/de0ea2b9-71c1-41cb-886e-e7145bfd3061" />
