### PR TITLE
use `as_ref()` for better readability

### DIFF
--- a/src/template/render.rs
+++ b/src/template/render.rs
@@ -21,7 +21,7 @@ impl Template {
             .segments
             .iter()
             .map(|segment| match segment {
-                Segment::Literal(text) => span(&**text),
+                Segment::Literal(text) => span(text.as_ref()),
                 Segment::Variable(var) => {
                     let (text, color) = self.resolve_variable(*var, data, colors);
                     span(text).font(cosmic::font::mono()).color_maybe(color)


### PR DESCRIPTION
replaces `&**` to  `as_ref()`  for enhance code readability while keeping the functionality

<img width="560" height="169" alt="image" src="https://github.com/user-attachments/assets/51670aea-7842-4158-8596-b0f44f168362" />
