### PR TITLE
Added Disk Usage Statistics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ sysinfo = { version = "0.39.3", default-features = false, features = [
 	"system",
 	"network",
 	"component",
+	"disk",
 ] }
 tracing = { version = "0.1.44", default-features = false, features = ["log"] }
 tracing-subscriber = { version = "0.3.23", default-features = false, features = [

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 
 - **CPU usage** — percentage of total CPU utilization
 - **RAM usage** — percentage of memory used (optionally including swap)
+- **Disk usage** — read and write activity of all disks in MB/s
 - **Network speed** — download and upload speeds in MB/s
 - **CPU temperature** — reads from common thermal sensors via sysinfo
 - **GPU temperature** — reads from sysinfo components (AMD/Intel), falls back to `nvidia-smi` for NVIDIA
@@ -50,6 +51,8 @@ CPU {cpu_usage} RAM {ram_usage} ↓{dl_speed}M/s ↑{ul_speed}M/s
 | `{ul_speed}` | Upload speed in MB/s (2 decimals) | `0.45` |
 | `{pub_ipv4}` | Public IPv4 address | `203.0.113.1` |
 | `{pub_ipv6}` | Public IPv6 address | `2001:db8::1` |
+| `{disk_read}` | Read activity of all disks in MB/s (2 decimals) | `34.5` |
+| `{disk_write}` | Write activity of all disks in MB/s (2 decimals) | `10.82` |
 
 When a sensor is not available, it shows `--` (e.g. `--°C`, `--%`).
 
@@ -59,9 +62,9 @@ Use `{{` and `}}` for literal braces in your template.
 
 All metrics with separators:
 ```
-{gpu_temp} {gpu_usage} | {cpu_temp} {cpu_usage} | {ram_usage} | ↓{dl_speed} ↑{ul_speed}
+{gpu_temp} {gpu_usage} | {cpu_temp} {cpu_usage} | {ram_usage} | ↓{dl_speed} ↑{ul_speed} | {disk_read} {disk_write}
 ```
-→ `48°C 3% | 51°C 45% | 67% | ↓1.23 ↑0.45`
+→ `48°C 3% | 51°C 45% | 67% | ↓1.23 ↑0.45 | 34.5 10.82`
 
 Grouped by category:
 ```

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -7,6 +7,7 @@ use sysinfo_mock::{Component, Components};
 
 use std::{
     cell::LazyCell,
+    collections::HashSet,
     fs,
     path::Path,
     process::Command,
@@ -26,6 +27,41 @@ const IP_REFRESH_INTERVAL: Duration = Duration::from_secs(300);
 enum IpVersion {
     V4,
     V6,
+}
+
+pub(crate) struct Disk {
+    disks: sysinfo::Disks,
+
+    pub(crate) read: Option<f64>,
+    pub(crate) write: Option<f64>,
+}
+
+impl Disk {
+    fn new() -> Self {
+        Self {
+            read: None,
+            write: None,
+            disks: sysinfo::Disks::new_with_refreshed_list(),
+        }
+    }
+
+    fn refresh_disks(&mut self) {
+        self.disks.refresh(true);
+        let mut seen = HashSet::new();
+        let (mut read, mut write) = (0u64, 0u64);
+
+        for disk in self.disks.list() {
+            if !seen.insert(disk.name()) {
+                continue;
+            }
+
+            read += disk.usage().read_bytes;
+            write += disk.usage().written_bytes;
+        }
+
+        self.read = Some(read as f64 / 1_000_000.0);
+        self.write = Some(write as f64 / 1_000_000.0);
+    }
 }
 
 pub(crate) struct Npu {
@@ -116,6 +152,7 @@ pub(crate) struct Data {
     pub(crate) gpu_usage: Option<u64>,
     pub(crate) public_ipv4: Option<String>,
     pub(crate) public_ipv6: Option<String>,
+    pub(crate) disks: Disk,
 }
 
 impl Data {
@@ -125,6 +162,7 @@ impl Data {
         let components = Components::new_with_refreshed_list();
         let physical_interfaces = Self::detect_physical_interfaces(config);
         let npu_data = Npu::new();
+        let disks_data = Disk::new();
 
         let ip_backoff = ExponentialBackoff {
             max_interval: IP_REFRESH_INTERVAL,
@@ -151,6 +189,7 @@ impl Data {
             npu: npu_data,
             public_ipv4: None,
             public_ipv6: None,
+            disks: disks_data,
         }
     }
 
@@ -167,6 +206,8 @@ impl Data {
         let needs_pub_ipv6 = requires.contains(Variable::PublicIpv6);
         let needs_npu_usage = requires.contains(Variable::NpuUsage);
         let needs_npu_frequency = requires.contains(Variable::NpuFrequency);
+        let needs_disk_read = requires.contains(Variable::DiskRead);
+        let needs_disk_write = requires.contains(Variable::DiskWrite);
 
         if (needs_download || needs_upload)
             && self.last_interface_scan.elapsed() > Duration::from_secs(10)
@@ -305,6 +346,11 @@ impl Data {
         }
         if !needs_pub_ipv6 {
             self.public_ipv6 = None;
+        }
+
+        // Disk
+        if needs_disk_read || needs_disk_write {
+            self.disks.refresh_disks();
         }
 
         // NPU

--- a/src/template/mod.rs
+++ b/src/template/mod.rs
@@ -1,8 +1,8 @@
 use std::fmt::Debug;
 
 use crate::template::Variable::{
-    CpuTemp, CpuUsage, DlSpeed, GpuTemp, GpuUsage, NpuFrequency, NpuUsage, PublicIpv4, PublicIpv6,
-    RamUsage, UlSpeed,
+    CpuTemp, CpuUsage, DiskRead, DiskWrite, DlSpeed, GpuTemp, GpuUsage, NpuFrequency, NpuUsage,
+    PublicIpv4, PublicIpv6, RamUsage, UlSpeed,
 };
 
 mod parse;
@@ -28,9 +28,11 @@ pub(crate) enum Variable {
     PublicIpv6 = 8,
     NpuUsage = 9,
     NpuFrequency = 10,
+    DiskRead = 11,
+    DiskWrite = 12,
 }
 
-const ALL_VARIABLES: [Variable; 11] = [
+const ALL_VARIABLES: [Variable; 13] = [
     CpuUsage,
     RamUsage,
     CpuTemp,
@@ -42,6 +44,8 @@ const ALL_VARIABLES: [Variable; 11] = [
     PublicIpv6,
     NpuUsage,
     NpuFrequency,
+    DiskRead,
+    DiskWrite,
 ];
 
 impl Variable {
@@ -88,6 +92,8 @@ impl Debug for Requires {
                 PublicIpv6 => "pub_ipv6",
                 NpuUsage => "npu_usage",
                 NpuFrequency => "npu_frequency",
+                DiskRead => "disk_read",
+                DiskWrite => "disk_write",
             })
             .collect();
 

--- a/src/template/parse.rs
+++ b/src/template/parse.rs
@@ -82,6 +82,8 @@ impl FromStr for Variable {
             "pub_ipv6" => Ok(Self::PublicIpv6),
             "npu_usage" => Ok(Self::NpuUsage),
             "npu_frequency" => Ok(Self::NpuFrequency),
+            "disk_read" => Ok(Self::DiskRead),
+            "disk_write" => Ok(Self::DiskWrite),
             _ => Err(()),
         }
     }
@@ -113,7 +115,7 @@ mod test {
             insta::assert_debug_snapshot!(
                 "all_metrics_with_separators",
                 parse(
-                    "{gpu_temp} {gpu_usage} | {cpu_temp} {cpu_usage} | {ram_usage} | ↓{dl_speed} ↑{ul_speed} | {pub_ipv4} {pub_ipv6}",
+                    "{gpu_temp} {gpu_usage} | {cpu_temp} {cpu_usage} | {ram_usage} | ↓{dl_speed} ↑{ul_speed} | {pub_ipv4} {pub_ipv6} | {disk_read} {disk_write}",
                 ),
             );
             insta::assert_debug_snapshot!(

--- a/src/template/render.rs
+++ b/src/template/render.rs
@@ -110,6 +110,14 @@ impl Template {
                 Some(f) => (format!("{f:>2}MHz").into(), None),
                 None => ("--".into(), None),
             },
+            Variable::DiskRead => match data.disks.read {
+                Some(s) => (format!("{s:4.1}").into(), None),
+                None => (" -.-".into(), None),
+            },
+            Variable::DiskWrite => match data.disks.write {
+                Some(s) => (format!("{s:4.1}").into(), None),
+                None => (" -.-".into(), None),
+            },
         }
     }
 }

--- a/src/template/snapshots/all_metrics_with_separators.snap
+++ b/src/template/snapshots/all_metrics_with_separators.snap
@@ -1,6 +1,7 @@
 ---
 source: src/template/parse.rs
-expression: "parse(\"{gpu_temp} {gpu_usage} | {cpu_temp} {cpu_usage} | {ram_usage} | ↓{dl_speed} ↑{ul_speed} | {pub_ipv4} {pub_ipv6}\",)"
+assertion_line: 115
+expression: "parse(\"{gpu_temp} {gpu_usage} | {cpu_temp} {cpu_usage} | {ram_usage} | ↓{dl_speed} ↑{ul_speed} | {pub_ipv4} {pub_ipv6} | {disk_read} {disk_write}\",)"
 ---
 Template {
     segments: [
@@ -55,6 +56,18 @@ Template {
         Variable(
             PublicIpv6,
         ),
+        Literal(
+            " | ",
+        ),
+        Variable(
+            DiskRead,
+        ),
+        Literal(
+            " ",
+        ),
+        Variable(
+            DiskWrite,
+        ),
     ],
     requires: {
         "cpu_usage",
@@ -66,5 +79,7 @@ Template {
         "ul_speed",
         "pub_ipv4",
         "pub_ipv6",
+        "disk_read",
+        "disk_write",
     },
 }


### PR DESCRIPTION
Hello! I wanted to add support for displaying disk read and write values.

The read/write values of all disks (or more precisely, all mount points) are summed up and displayed as a single value.

I used a HashSet to filter out duplicate devices because disks.list() returns a list of mount points and not a list of drives or partitions. In my case, both "/" and "/home" are mounted from the same partition. Since the read/write statistics are tied to the partitions rather than the mount points, iterating over all mount points caused my partition to be counted twice.
By keeping track of the partition names in a HashSet, each partition is only counted once, preventing duplicated read/write values.