### PR TITLE
Detect GPU usage and temperature for Intel Arc (xe driver)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 - **Network speed** — download and upload speeds in MB/s
 - **CPU temperature** — reads from common thermal sensors via sysinfo
 - **GPU temperature** — reads from sysinfo components (AMD/Intel), falls back to `nvidia-smi` for NVIDIA
-- **GPU usage** — reads from sysfs (`gpu_busy_percent`), falls back to `nvidia-smi` for NVIDIA
+- **GPU usage** — reads from sysfs (`gpu_busy_percent` for AMD, GT idle residency for Intel xe), falls back to `nvidia-smi` for NVIDIA
 - **NPU usage** — reads from sysfs (`npu_busy_time_us`) and calculates the NPU utilization.
 - **NPU frequency** — reads from sysfs (`npu_current_frequency_mhz`).
 - **Public IPv4 / IPv6** — fetches your public IP addresses via `curl` (using [icanhazip.com](https://icanhazip.com)), cached for 5 minutes

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -130,25 +130,77 @@ impl Npu {
     }
 }
 
-/// GPU usage for cards driven by the Intel `xe` driver, which exposes no
-/// `gpu_busy_percent`. Busy time is derived from GT C6 idle residency:
-/// busy ≈ 100 - idle_time_delta / wall_time_delta.
-pub(crate) struct XeGpu {
+pub(crate) struct Gpu {
+    // sampling state for `refresh_xe_usage`
     last_sample_at: Option<Instant>,
     last_idle_ms: HashMap<PathBuf, u64>,
+
+    pub(crate) temp: Option<f32>,
+    pub(crate) usage: Option<u64>,
 }
 
-impl XeGpu {
+impl Gpu {
     fn new() -> Self {
         Self {
             last_sample_at: None,
             last_idle_ms: HashMap::new(),
+            temp: None,
+            usage: None,
         }
     }
 
-    /// Returns the busiest GT's usage percentage, or `None` before the first
-    /// sample or when no `xe` card is present.
-    fn refresh_usage(&mut self) -> Option<u64> {
+    fn refresh(&mut self, components: &Components, needs_temp: bool, needs_usage: bool) {
+        if !needs_temp && !needs_usage {
+            self.temp = None;
+            self.usage = None;
+            return;
+        }
+
+        // lazy nvidia-smi: answers both queries, spawned at most once
+        let nvidia = LazyCell::new(Self::query_nvidia_smi);
+
+        self.temp = if needs_temp {
+            Self::find_temp(components).or_else(|| nvidia.as_ref().and_then(|(t, _)| *t))
+        } else {
+            None
+        };
+        self.usage = if needs_usage {
+            Self::find_usage_sysfs()
+                .or_else(|| self.refresh_xe_usage())
+                .or_else(|| nvidia.as_ref().and_then(|(_, u)| *u))
+        } else {
+            None
+        };
+    }
+
+    fn find_temp(components: &Components) -> Option<f32> {
+        const LABELS: [&str; 10] = [
+            "amdgpu", "radeon", "nouveau", "nvidia", "gpu", "edge", "junction", "pkg", "vram",
+            "mem",
+        ];
+        LABELS.into_iter().find_map(|l| {
+            components
+                .iter()
+                .find(|c| c.label().to_lowercase().contains(l))
+                .and_then(|c| c.temperature())
+        })
+    }
+
+    fn find_usage_sysfs() -> Option<u64> {
+        let entries = fs::read_dir("/sys/class/drm").ok()?;
+        for entry in entries.flatten() {
+            if let Ok(contents) = fs::read_to_string(entry.path().join("device/gpu_busy_percent"))
+                && let Ok(value) = contents.trim().parse()
+            {
+                return Some(value);
+            }
+        }
+        None
+    }
+
+    /// Usage of the busiest GT for the Intel `xe` driver, derived from C6
+    /// idle residency: busy ≈ 100 - idle_time_delta / wall_time_delta.
+    fn refresh_xe_usage(&mut self) -> Option<u64> {
         let now = Instant::now();
         let samples = Self::read_idle_residency_ms();
 
@@ -173,8 +225,7 @@ impl XeGpu {
         usage
     }
 
-    /// Collect `idle_residency_ms` for every GT of every `xe` card
-    /// (`/sys/class/drm/card*/device/tile*/gt*/gtidle`).
+    /// Collect `/sys/class/drm/card*/device/tile*/gt*/gtidle/idle_residency_ms`.
     fn read_idle_residency_ms() -> HashMap<PathBuf, u64> {
         let mut samples = HashMap::new();
         let Ok(cards) = fs::read_dir("/sys/class/drm") else {
@@ -204,6 +255,36 @@ impl XeGpu {
 
         samples
     }
+
+    fn query_nvidia_smi() -> Option<(Option<f32>, Option<u64>)> {
+        let is_flatpak = Path::new("/.flatpak-info").exists();
+
+        let mut command = if is_flatpak {
+            let mut c = Command::new("flatpak-spawn");
+            c.args(["--host", "nvidia-smi"]);
+            c
+        } else {
+            Command::new("nvidia-smi")
+        };
+
+        let output = command
+            .args([
+                "--query-gpu=temperature.gpu,utilization.gpu",
+                "--format=csv,noheader,nounits",
+            ])
+            .output()
+            .ok()?;
+
+        if !output.status.success() {
+            return None;
+        }
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if let Some((temp, util)) = stdout.trim().split_once(", ") {
+            Some((temp.trim().parse().ok(), util.trim().parse().ok()))
+        } else {
+            Some((None, None))
+        }
+    }
 }
 
 /// The data coming from various sources (mostly the `sysinfo` crate)
@@ -219,14 +300,12 @@ pub(crate) struct Data {
     ip_backoff: ExponentialBackoff,
 
     pub(crate) npu: Npu,
-    xe_gpu: XeGpu,
+    pub(crate) gpu: Gpu,
     pub(crate) cpu_usage: Option<f32>,
     pub(crate) ram_usage: Option<u64>,
     pub(crate) download_speed: Option<f64>,
     pub(crate) upload_speed: Option<f64>,
     pub(crate) cpu_temp: Option<f32>,
-    pub(crate) gpu_temp: Option<f32>,
-    pub(crate) gpu_usage: Option<u64>,
     pub(crate) public_ipv4: Option<String>,
     pub(crate) public_ipv6: Option<String>,
     pub(crate) disks: Disk,
@@ -261,10 +340,8 @@ impl Data {
             download_speed: None,
             upload_speed: None,
             cpu_temp: None,
-            gpu_temp: None,
-            gpu_usage: None,
             npu: npu_data,
-            xe_gpu: XeGpu::new(),
+            gpu: Gpu::new(),
             public_ipv4: None,
             public_ipv6: None,
             disks: disks_data,
@@ -351,27 +428,9 @@ impl Data {
             None
         };
 
-        // GPU (lazy nvidia-smi)
-        if needs_gpu_temp || needs_gpu_usage {
-            let nvidia = LazyCell::new(Self::query_nvidia_smi);
-
-            self.gpu_temp = if needs_gpu_temp {
-                Self::find_gpu_temp(&self.components)
-                    .or_else(|| nvidia.as_ref().and_then(|(t, _)| *t))
-            } else {
-                None
-            };
-            self.gpu_usage = if needs_gpu_usage {
-                Self::find_gpu_usage_sysfs()
-                    .or_else(|| self.xe_gpu.refresh_usage())
-                    .or_else(|| nvidia.as_ref().and_then(|(_, u)| *u))
-            } else {
-                None
-            };
-        } else {
-            self.gpu_temp = None;
-            self.gpu_usage = None;
-        }
+        // GPU
+        self.gpu
+            .refresh(&self.components, needs_gpu_temp, needs_gpu_usage);
 
         // Public IPs — exponential backoff on failure, 5-minute cadence on success.
         // Only refresh if:
@@ -484,31 +543,6 @@ impl Data {
         })
     }
 
-    fn find_gpu_temp(components: &Components) -> Option<f32> {
-        const LABELS: [&str; 10] = [
-            "amdgpu", "radeon", "nouveau", "nvidia", "gpu", "edge", "junction", "pkg", "vram",
-            "mem",
-        ];
-        LABELS.into_iter().find_map(|l| {
-            components
-                .iter()
-                .find(|c| c.label().to_lowercase().contains(l))
-                .and_then(|c| c.temperature())
-        })
-    }
-
-    fn find_gpu_usage_sysfs() -> Option<u64> {
-        let entries = fs::read_dir("/sys/class/drm").ok()?;
-        for entry in entries.flatten() {
-            if let Ok(contents) = fs::read_to_string(entry.path().join("device/gpu_busy_percent"))
-                && let Ok(value) = contents.trim().parse()
-            {
-                return Some(value);
-            }
-        }
-        None
-    }
-
     fn find_npu_busy_time_us_sysfs() -> Option<u64> {
         let entries = fs::read_dir("/sys/class/accel").ok()?;
         for entry in entries.flatten() {
@@ -553,36 +587,6 @@ impl Data {
         let ip = response.text().ok()?.trim().to_string();
 
         (!ip.is_empty()).then_some(ip)
-    }
-
-    fn query_nvidia_smi() -> Option<(Option<f32>, Option<u64>)> {
-        let is_flatpak = Path::new("/.flatpak-info").exists();
-
-        let mut command = if is_flatpak {
-            let mut c = Command::new("flatpak-spawn");
-            c.args(["--host", "nvidia-smi"]);
-            c
-        } else {
-            Command::new("nvidia-smi")
-        };
-
-        let output = command
-            .args([
-                "--query-gpu=temperature.gpu,utilization.gpu",
-                "--format=csv,noheader,nounits",
-            ])
-            .output()
-            .ok()?;
-
-        if !output.status.success() {
-            return None;
-        }
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        if let Some((temp, util)) = stdout.trim().split_once(", ") {
-            Some((temp.trim().parse().ok(), util.trim().parse().ok()))
-        } else {
-            Some((None, None))
-        }
     }
 }
 
@@ -636,7 +640,7 @@ mod test {
 
             // do match on the component, even though `amdgpu` is only a _part_
             // of its name
-            assert_eq!(Data::find_gpu_temp(&components), Some(1.0));
+            assert_eq!(Gpu::find_temp(&components), Some(1.0));
         }
 
         #[test]
@@ -654,7 +658,7 @@ mod test {
 
             // choose `junction` over `mem` despite `mem` coming earlier
             // in `components`, because `junction` comes earlier in `LABELS`
-            assert_eq!(Data::find_gpu_temp(&components), Some(2.0));
+            assert_eq!(Gpu::find_temp(&components), Some(2.0));
         }
 
         #[test]
@@ -670,9 +674,8 @@ mod test {
                 },
             ]);
 
-            // the Intel xe driver labels the die temperature `pkg`; prefer it
-            // over the memory temperature `vram`
-            assert_eq!(Data::find_gpu_temp(&components), Some(2.0));
+            // prefer the xe die temperature `pkg` over the memory one `vram`
+            assert_eq!(Gpu::find_temp(&components), Some(2.0));
         }
     }
 }

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -7,9 +7,9 @@ use sysinfo_mock::{Component, Components};
 
 use std::{
     cell::LazyCell,
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     fs,
-    path::Path,
+    path::{Path, PathBuf},
     process::Command,
     time::{Duration, Instant},
 };
@@ -130,6 +130,82 @@ impl Npu {
     }
 }
 
+/// GPU usage for cards driven by the Intel `xe` driver, which exposes no
+/// `gpu_busy_percent`. Busy time is derived from GT C6 idle residency:
+/// busy ≈ 100 - idle_time_delta / wall_time_delta.
+pub(crate) struct XeGpu {
+    last_sample_at: Option<Instant>,
+    last_idle_ms: HashMap<PathBuf, u64>,
+}
+
+impl XeGpu {
+    fn new() -> Self {
+        Self {
+            last_sample_at: None,
+            last_idle_ms: HashMap::new(),
+        }
+    }
+
+    /// Returns the busiest GT's usage percentage, or `None` before the first
+    /// sample or when no `xe` card is present.
+    fn refresh_usage(&mut self) -> Option<u64> {
+        let now = Instant::now();
+        let samples = Self::read_idle_residency_ms();
+
+        let usage = self.last_sample_at.and_then(|last| {
+            let wall_ms = u64::try_from(now.duration_since(last).as_millis()).ok()?;
+            if wall_ms == 0 {
+                return None;
+            }
+            samples
+                .iter()
+                .filter_map(|(path, idle_ms)| {
+                    let previous = self.last_idle_ms.get(path)?;
+                    let idle_delta = idle_ms.saturating_sub(*previous);
+                    Some(100 - (idle_delta * 100 / wall_ms).min(100))
+                })
+                .max()
+        });
+
+        self.last_sample_at = Some(now);
+        self.last_idle_ms = samples;
+
+        usage
+    }
+
+    /// Collect `idle_residency_ms` for every GT of every `xe` card
+    /// (`/sys/class/drm/card*/device/tile*/gt*/gtidle`).
+    fn read_idle_residency_ms() -> HashMap<PathBuf, u64> {
+        let mut samples = HashMap::new();
+        let Ok(cards) = fs::read_dir("/sys/class/drm") else {
+            return samples;
+        };
+
+        let subdirs = |path: PathBuf, prefix: &'static str| {
+            fs::read_dir(path)
+                .into_iter()
+                .flatten()
+                .flatten()
+                .filter(move |e| e.file_name().to_string_lossy().starts_with(prefix))
+        };
+
+        for card in cards.flatten() {
+            for tile in subdirs(card.path().join("device"), "tile") {
+                for gt in subdirs(tile.path(), "gt") {
+                    let path = gt.path().join("gtidle/idle_residency_ms");
+                    if let Ok(contents) = fs::read_to_string(&path)
+                        && let Ok(value) = contents.trim().parse()
+                    {
+                        samples.insert(path, value);
+                    }
+                }
+            }
+        }
+
+        samples
+    }
+}
+
 /// The data coming from various sources (mostly the `sysinfo` crate)
 ///
 /// Manages each source, and stores the values extracted from them
@@ -143,6 +219,7 @@ pub(crate) struct Data {
     ip_backoff: ExponentialBackoff,
 
     pub(crate) npu: Npu,
+    xe_gpu: XeGpu,
     pub(crate) cpu_usage: Option<f32>,
     pub(crate) ram_usage: Option<u64>,
     pub(crate) download_speed: Option<f64>,
@@ -187,6 +264,7 @@ impl Data {
             gpu_temp: None,
             gpu_usage: None,
             npu: npu_data,
+            xe_gpu: XeGpu::new(),
             public_ipv4: None,
             public_ipv6: None,
             disks: disks_data,
@@ -284,7 +362,9 @@ impl Data {
                 None
             };
             self.gpu_usage = if needs_gpu_usage {
-                Self::find_gpu_usage_sysfs().or_else(|| nvidia.as_ref().and_then(|(_, u)| *u))
+                Self::find_gpu_usage_sysfs()
+                    .or_else(|| self.xe_gpu.refresh_usage())
+                    .or_else(|| nvidia.as_ref().and_then(|(_, u)| *u))
             } else {
                 None
             };
@@ -405,8 +485,9 @@ impl Data {
     }
 
     fn find_gpu_temp(components: &Components) -> Option<f32> {
-        const LABELS: [&str; 8] = [
-            "amdgpu", "radeon", "nouveau", "nvidia", "gpu", "edge", "junction", "mem",
+        const LABELS: [&str; 10] = [
+            "amdgpu", "radeon", "nouveau", "nvidia", "gpu", "edge", "junction", "pkg", "vram",
+            "mem",
         ];
         LABELS.into_iter().find_map(|l| {
             components
@@ -573,6 +654,24 @@ mod test {
 
             // choose `junction` over `mem` despite `mem` coming earlier
             // in `components`, because `junction` comes earlier in `LABELS`
+            assert_eq!(Data::find_gpu_temp(&components), Some(2.0));
+        }
+
+        #[test]
+        fn intel_xe() {
+            let components = Components::from(vec![
+                Component {
+                    label: "xe vram",
+                    temperature: 1.0,
+                },
+                Component {
+                    label: "xe pkg",
+                    temperature: 2.0,
+                },
+            ]);
+
+            // the Intel xe driver labels the die temperature `pkg`; prefer it
+            // over the memory temperature `vram`
             assert_eq!(Data::find_gpu_temp(&components), Some(2.0));
         }
     }

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -225,7 +225,8 @@ impl Gpu {
         usage
     }
 
-    /// Collect `/sys/class/drm/card*/device/tile*/gt*/gtidle/idle_residency_ms`.
+    /// Collect `idle_residency_ms` for every GT of every `xe` card
+    /// (`/sys/class/drm/card*/device/tile*/gt*/gtidle`).
     fn read_idle_residency_ms() -> HashMap<PathBuf, u64> {
         let mut samples = HashMap::new();
         let Ok(cards) = fs::read_dir("/sys/class/drm") else {

--- a/src/template/render.rs
+++ b/src/template/render.rs
@@ -69,14 +69,14 @@ impl Template {
                 ),
                 None => ("--°C".into(), None),
             },
-            Variable::GpuTemp => match data.gpu_temp {
+            Variable::GpuTemp => match data.gpu.temp {
                 Some(t) => (
                     format!("{t:>2.0}°C").into(),
                     colors.threshold(t as f64, 60.0, 85.0),
                 ),
                 None => ("--°C".into(), None),
             },
-            Variable::GpuUsage => match data.gpu_usage {
+            Variable::GpuUsage => match data.gpu.usage {
                 Some(v) => (
                     format!("{v:>2}%").into(),
                     colors.threshold(v as f64, 50.0, 80.0),


### PR DESCRIPTION
*Problem*

On Intel Arc cards using the xe kernel driver (tested on an Arc B580), both {gpu_temp} and {gpu_usage} render as --:

- The xe hwmon labels its sensors pkg (die) and vram (memory), and none of those matched the temperature label list.
- The usage path reads gpu_busy_percent from sysfs, while xe exposes no equivalent.

*Changes*

- Add pkg and vram to the GPU hwmon label list, with pkg prioritized so the die temperature wins over memory.
- Derive usage for xe cards from GT C6 idle residency (/sys/class/drm/card*/device/tile*/gt*/gtidle/idle_residency_ms): busy = 100 - idle_time_delta / wall_time_delta, reporting the busiest GT (discrete Arc has separate render and media GTs). Sits between the sysfs path and the nvidia-smi fallback, so other vendors are unaffected. The first tick returns no value since a baseline sample is needed.

*Important*

In my first commit, the solution did not fit well with the code base standard, so I refactored the GPU state. Probing now live in a Gpu struct mirroring Npu/Disk (data.gpu.temp, data.gpu.usage) instead of loose fields on Data.

*Notes*

C6 residency measures "not power-gated" rather than true engine utilization, so it can read slightly high under light load. The exact alternative (aggregating drm-cycles-* from /proc/*/fdinfo, as nvtop does) is considerably more code and only sees the current user's clients; residency seemed like the right cost/benefit for an applet, but happy to switch if preferred.

*Testing*

- cargo test passes, including a new label-priority test for xe.
- Verified on an Arc B580 (Battlemage) on Arch: temperature reads from the xe pkg sensor, and usage tracks load sensibly.