### PR TITLE
fix: add uv inline metadata to flatpak-cargo-generator.py

### DIFF
--- a/flatpak/flatpak-cargo-generator.py
+++ b/flatpak/flatpak-cargo-generator.py
@@ -1,4 +1,11 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "aiohttp",
+#   "toml",
+# ]
+# ///
 
 __license__ = "MIT"
 import argparse


### PR DESCRIPTION
@rwxroot , I took some time to try flatpak. I may have found an issue.

## Problem

`flatpak/generate-cargo-sources.sh` runs the generator with `uv run --script`, but `flatpak-cargo-generator.py` declares no dependencies. uv therefore runs it in a bare environment and it crashes immediately:

```
ModuleNotFoundError: No module named 'aiohttp'
```

This breaks the flatpak packaging workflow at the source-generation step for everyone using the script as shipped (uv isolates script runs from globally installed packages anyway).

The flatpak manifest and build itself are fine: with a properly generated `cargo-sources.json`, `flatpak-builder` builds the applet cleanly against the FreeDesktop 25.08 runtime.

## Fix

Add a PEP 723 inline script metadata block declaring the required dependencies:

```python
# /// script
# requires-python = ">=3.9"
# dependencies = [
#   "aiohttp",
#   "toml",
# ]
# ///
```

`uv run --script` reads this block and provisions the environment automatically. `pyyaml` is intentionally left out: the script imports it optionally and it is not needed for JSON output.

## Testing

- `./flatpak/generate-cargo-sources.sh` now completes as shipped and produces `cargo-sources.json`.
- `flatpak-builder --force-clean --user --install-deps-from=flathub build-dir io.github.cosmic_utils.sysinfo-applet.json` builds successfully with the generated sources.
