### PR TITLE
Add disk space stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ CPU {cpu_usage} RAM {ram_usage} ↓{dl_speed}M/s ↑{ul_speed}M/s
 | `{pub_ipv6}` | Public IPv6 address | `2001:db8::1` |
 | `{disk_read}` | Read activity of all disks in MB/s (2 decimals) | `34.5` |
 | `{disk_write}` | Write activity of all disks in MB/s (2 decimals) | `10.82` |
+| `{disk_used}` | Used space of all disks in GB | `195.2GB` |
+| `{disk_usage}` | Used space of all disks % | `65%` |
 
 When a sensor is not available, it shows `--` (e.g. `--°C`, `--%`).
 
@@ -108,6 +110,7 @@ Values are automatically colour-coded using COSMIC theme colours:
 | GPU temp | < 60°C | 60–85°C | ≥ 85°C |
 | GPU usage | < 50% | 50–80% | ≥ 80% |
 | VRAM usage | < 50% | 50–80% | ≥ 80% |
+| Disk usage | < 75% | 75-90% | ≥ 90% |
 
 Download/upload speeds and public IPs are not colour-coded.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,7 +18,7 @@ pub(crate) struct SysInfoConfig {
     /// Template string controlling the applet display.
     /// Available variables: {cpu_usage}, {ram_usage}, {cpu_temp}, {gpu_temp}, {gpu_usage},
     /// {vram_usage}, {npu_usage}, {npu_frequency}, {dl_speed}, {ul_speed}, {pub_ipv4},
-    /// {pub_ipv6}, {disk_read}, {disk_write}
+    /// {pub_ipv6}, {disk_read}, {disk_write}, {disk_used}, {disk_usage}
     pub(crate) template: String,
 }
 

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -35,6 +35,8 @@ pub(crate) struct Disk {
 
     pub(crate) read: Option<f64>,
     pub(crate) write: Option<f64>,
+    pub(crate) used: Option<u64>,
+    pub(crate) usage: Option<u64>,
 }
 
 impl Disk {
@@ -42,6 +44,8 @@ impl Disk {
         Self {
             read: None,
             write: None,
+            used: None,
+            usage: None,
             disks: sysinfo::Disks::new_with_refreshed_list(),
         }
     }
@@ -50,6 +54,7 @@ impl Disk {
         self.disks.refresh(true);
         let mut seen = HashSet::new();
         let (mut read, mut write) = (0u64, 0u64);
+        let (mut total, mut available) = (0, 0);
 
         for disk in self.disks.list() {
             if !seen.insert(disk.name()) {
@@ -58,10 +63,16 @@ impl Disk {
 
             read += disk.usage().read_bytes;
             write += disk.usage().written_bytes;
+            total += disk.total_space();
+            available += disk.available_space();
         }
+
+        let used = total - available;
 
         self.read = Some(read as f64 / 1_000_000.0);
         self.write = Some(write as f64 / 1_000_000.0);
+        self.used = Some(used / 1_000_000_000);
+        self.usage = Some(100 * used / total);
     }
 }
 
@@ -529,6 +540,8 @@ impl Data {
         let needs_npu_frequency = requires.contains(Variable::NpuFrequency);
         let needs_disk_read = requires.contains(Variable::DiskRead);
         let needs_disk_write = requires.contains(Variable::DiskWrite);
+        let needs_disk_used = requires.contains(Variable::DiskUsed);
+        let needs_disk_usage = requires.contains(Variable::DiskUsage);
 
         if (needs_download || needs_upload)
             && self.last_interface_scan.elapsed() > Duration::from_secs(10)
@@ -653,7 +666,7 @@ impl Data {
         }
 
         // Disk
-        if needs_disk_read || needs_disk_write {
+        if needs_disk_read || needs_disk_write || needs_disk_used || needs_disk_usage {
             self.disks.refresh_disks();
         }
 

--- a/src/template/mod.rs
+++ b/src/template/mod.rs
@@ -1,8 +1,8 @@
 use std::fmt::Debug;
 
 use crate::template::Variable::{
-    CpuTemp, CpuUsage, DiskRead, DiskWrite, DlSpeed, GpuTemp, GpuUsage, NpuFrequency, NpuUsage,
-    PublicIpv4, PublicIpv6, RamUsage, UlSpeed, VramUsage,
+    CpuTemp, CpuUsage, DiskRead, DiskUsage, DiskUsed, DiskWrite, DlSpeed, GpuTemp, GpuUsage,
+    NpuFrequency, NpuUsage, PublicIpv4, PublicIpv6, RamUsage, UlSpeed, VramUsage
 };
 
 mod parse;
@@ -31,9 +31,11 @@ pub(crate) enum Variable {
     DiskRead = 11,
     DiskWrite = 12,
     VramUsage = 13,
+    DiskUsed = 14,
+    DiskUsage = 15,
 }
 
-const ALL_VARIABLES: [Variable; 14] = [
+const ALL_VARIABLES: [Variable; 16] = [
     CpuUsage,
     RamUsage,
     CpuTemp,
@@ -48,6 +50,8 @@ const ALL_VARIABLES: [Variable; 14] = [
     DiskRead,
     DiskWrite,
     VramUsage,
+    DiskUsed,
+    DiskUsage,
 ];
 
 impl Variable {
@@ -97,6 +101,8 @@ impl Debug for Requires {
                 DiskRead => "disk_read",
                 DiskWrite => "disk_write",
                 VramUsage => "vram_usage",
+                DiskUsed => "disk_used",
+                DiskUsage => "disk_usage",
             })
             .collect();
 

--- a/src/template/mod.rs
+++ b/src/template/mod.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use crate::template::Variable::{
     CpuTemp, CpuUsage, DiskRead, DiskUsage, DiskUsed, DiskWrite, DlSpeed, GpuTemp, GpuUsage,
-    NpuFrequency, NpuUsage, PublicIpv4, PublicIpv6, RamUsage, UlSpeed, VramUsage
+    NpuFrequency, NpuUsage, PublicIpv4, PublicIpv6, RamUsage, UlSpeed, VramUsage,
 };
 
 mod parse;

--- a/src/template/parse.rs
+++ b/src/template/parse.rs
@@ -85,6 +85,8 @@ impl FromStr for Variable {
             "npu_frequency" => Ok(Self::NpuFrequency),
             "disk_read" => Ok(Self::DiskRead),
             "disk_write" => Ok(Self::DiskWrite),
+            "disk_used" => Ok(Self::DiskUsed),
+            "disk_usage" => Ok(Self::DiskUsage),
             _ => Err(()),
         }
     }
@@ -116,7 +118,7 @@ mod test {
             insta::assert_debug_snapshot!(
                 "all_metrics_with_separators",
                 parse(
-                    "{gpu_temp} {gpu_usage} | {cpu_temp} {cpu_usage} | {ram_usage} | ↓{dl_speed} ↑{ul_speed} | {pub_ipv4} {pub_ipv6} | {disk_read} {disk_write}",
+                    "{gpu_temp} {gpu_usage} | {cpu_temp} {cpu_usage} | {ram_usage} | ↓{dl_speed} ↑{ul_speed} | {pub_ipv4} {pub_ipv6} | {disk_read} {disk_write} | {disk_used} {disk_usage}",
                 ),
             );
             insta::assert_debug_snapshot!(

--- a/src/template/render.rs
+++ b/src/template/render.rs
@@ -125,6 +125,17 @@ impl Template {
                 Some(s) => (format!("{s:4.1}").into(), None),
                 None => (" -.-".into(), None),
             },
+            Variable::DiskUsed => match data.disks.used {
+                Some(s) => (format!("{s:4.1}GB").into(), None),
+                None => ("-.-".into(), None),
+            },
+            Variable::DiskUsage => match data.disks.usage {
+                Some(s) => (
+                    format!("{s:>2}%").into(),
+                    colors.threshold(s as f64, 75.0, 90.0),
+                ),
+                None => ("--%".into(), None),
+            },
         }
     }
 }

--- a/src/template/snapshots/all_metrics_with_separators.snap
+++ b/src/template/snapshots/all_metrics_with_separators.snap
@@ -68,6 +68,18 @@ Template {
         Variable(
             DiskWrite,
         ),
+        Literal(
+            " | ",
+        ),
+        Variable(
+            DiskUsed,
+        ),
+        Literal(
+            " ",
+        ),
+        Variable(
+            DiskUsage,
+        ),
     ],
     requires: {
         "cpu_usage",
@@ -81,5 +93,7 @@ Template {
         "pub_ipv6",
         "disk_read",
         "disk_write",
+        "disk_used",
+        "disk_usage",
     },
 }


### PR DESCRIPTION
This PR adds two new template variables, `{disk_used}`[^1] (used disk space in GB) and `{disk_usage}` (percentage of total disk space used)

<img width="601" height="412" alt="Screenshot_2026-08-30_21-29-34" src="https://github.com/user-attachments/assets/00b5bcc4-c87e-496d-a3ca-e19606d4be9c" />

[^1]: I'm not 100% sure about this name. Open to suggestions